### PR TITLE
Fix editorial-language inconsistencies in nav, footer, and copy buttons

### DIFF
--- a/src/lib/components/BaseModal.svelte
+++ b/src/lib/components/BaseModal.svelte
@@ -26,8 +26,18 @@
   } = $props();
 
   let portalElement = $state<HTMLElement | null>(null);
+  let dialogElement = $state<HTMLDialogElement | null>(null);
+
   onMount(() => {
     portalElement = document.body;
+  });
+
+  $effect(() => {
+    if (open) {
+      dialogElement?.showModal();
+    } else {
+      dialogElement?.close();
+    }
   });
 </script>
 
@@ -36,9 +46,8 @@
   <div use:portal={portalElement} class="portal-wrapper">
     <div class="backdrop" role="presentation" onclick={onClose}></div>
     <dialog
-      {open}
+      bind:this={dialogElement}
       class="base-modal"
-      aria-modal="true"
       aria-label={title}
       oncancel={(event) => {
         event.preventDefault();

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -95,10 +95,10 @@
         {/if}
       </div>
       <div class="footer-symbols">
-        <a href="https://bsky.app/profile/{PUBLIC_ATPROTO_DID}" aria-label="Bluesky" class="footer-icon-link">
+        <a href="https://bsky.app/profile/{PUBLIC_ATPROTO_DID}" target="_blank" rel="noopener" aria-label="Bluesky" class="footer-icon-link">
           <Bluesky size={14} />
         </a>
-        <a href="https://eurosky.tech" aria-label="Eurosky" class="footer-icon-link">
+        <a href="https://eurosky.tech" target="_blank" rel="noopener" aria-label="Eurosky" class="footer-icon-link">
           <Eurosky size={14} />
         </a>
         <WolfToggle />
@@ -110,7 +110,7 @@
       <nav class="footer-nav" aria-label="Footer navigation">
         <a href={`mailto:${contactEmail}`} class="footer-link">{contactEmail}</a>
         {#if primaryRepository}
-          <a href={primaryRepository.url} rel="noopener" class="footer-link">source</a>
+          <a href={primaryRepository.url} target="_blank" rel="noopener" class="footer-link">source</a>
         {/if}
         {#if projectLicense?.url}
           <a href={projectLicense.url} rel="license noopener" class="footer-link">{projectLicense.name ?? 'license'}</a>

--- a/src/lib/styles/components.css
+++ b/src/lib/styles/components.css
@@ -168,7 +168,12 @@
 
     .nav-link:hover,
     .nav-link.active {
-      background: var(--surface-sunken);
+      color: var(--color-primary-700);
+      background: color-mix(
+        in oklch,
+        var(--color-primary-500) 12%,
+        var(--surface-sunken)
+      );
       box-shadow: none;
     }
   }

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -270,9 +270,10 @@
         <dl class="id-list">
           <dt>DID</dt>
           <dd>
-            <button 
-              type="button" 
-              class="copy-btn copy-btn--compact" 
+            <button
+              type="button"
+              class="copy-btn copy-btn--compact"
+              aria-live="polite"
               onclick={() => copyToClipboard(profile.did, 'did')}
             >
               {copiedIndex === 'did' ? 'Copied' : 'Copy DID'}

--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -95,6 +95,7 @@
             type="button"
             class="copy-btn"
             aria-label="Copy {crypto.coin} address"
+            aria-live="polite"
             onclick={() => copyAddress(crypto.address, i)}
           >
             {#if copiedIndex === i}


### PR DESCRIPTION
- Mobile nav dropdown lost the primary accent on hover/active that the
  desktop nav already shows; align it with the same primary-tinted
  treatment used by other editorial rows.
- Footer's Bluesky/Eurosky/source links were missing target="_blank" and
  rel="noopener", unlike every other external link on the site.
- Copy-to-clipboard buttons on /about and /support didn't announce their
  "Copied" state change, unlike ShareButtons; add aria-live="polite" to
  match.