### PR TITLE
Fix GitHub Sponsors link on support page

### DIFF
--- a/src/routes/support/+page.svelte
+++ b/src/routes/support/+page.svelte
@@ -36,7 +36,7 @@ import { Coffee, GitPullRequest, Heart } from '@lucide/svelte';
         <span class="row-meta">One-time or monthly</span>
       </a>
       <a
-        href="https://github.com/sponsors/ewanc26/sponsorships"
+        href="https://github.com/sponsors/ewanc26"
         target="_blank"
         rel="noopener noreferrer"
         class="post-row"


### PR DESCRIPTION
## Summary
- point the GitHub Sponsors card at the public sponsor profile instead of the direct sponsorship checkout route

## Change
- `https://github.com/sponsors/ewanc26/sponsorships` → `https://github.com/sponsors/ewanc26`

The diff is intentionally limited to the broken link on `/support`.