### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Check, test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PUBLIC_ATPROTO_DID: did:plc:aaaaaaaaaaaaaaaaaaaaaaaa
+      PUBLIC_LEAFLET_BLOG_PUBLICATION: 3aaaaaaaaaaaa
+      PUBLIC_SITE_TITLE: CI
+      PUBLIC_SITE_DESCRIPTION: CI validation build
+      GITHUB_USERNAME: octocat
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type and Svelte check
+        run: pnpm check
+
+      - name: Run focused tests
+        run: pnpm test:site-info
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary

Add a small GitHub Actions CI workflow for the website repository.

- run on pull requests targeting `main` and pushes to `main`
- use Node.js 24 and pnpm 10 with pnpm dependency caching
- install strictly from `pnpm-lock.yaml` with `--frozen-lockfile`
- run `pnpm check`, the existing `pnpm test:site-info`, and `pnpm build`
- use only inert compile-time environment placeholders; no repository secrets are required
- keep workflow permissions read-only and cancel superseded runs on the same ref

This makes the repository's documented validation path visible as a required CI signal instead of relying only on Vercel builds.